### PR TITLE
Adds the use of the Appengine Development Server

### DIFF
--- a/src/sbt-test/sbt-appengine/helloxmpp/project/plugins.sbt
+++ b/src/sbt-test/sbt-appengine/helloxmpp/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-appengine" % "0.3.1")
+addSbtPlugin("com.eed3si9n" % "sbt-appengine" % "0.3.2-SNAPSHOT")


### PR DESCRIPTION
I added the ability to launch the appengine development server, which is needed for testing the datastore.

I wanted to adhere to the best practices, and make this a running process that does not require an exit hook.

> You can certainly add shutdown hooks, but they are susceptible to class loader leaks
> and will only run when you exit sbt.  It isn't good to use shutdown hooks for a normal
> build process, especially one that is publicly published, but you could get away with
> it as a local hack.

With that in mind, I made it run until the user presses enter. An explicit run that requires an explicit exit. This makes sense for this action anyway, is it requires the app to be packaged.
