### PR TITLE
use sbt-revolver to track the forked development server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ export environment variables (actually, JRebel support is not ported yet).
 put the following in the `project/plugins.sbt`:
 
 ```scala
+resolvers += "spray repo" at "http://repo.spray.cc"
+
 addSbtPlugin("com.eed3si9n" % "sbt-appengine" % "0.3.1")
 ```
 
@@ -36,6 +38,14 @@ lazy val example = Project("web", file("web"),
 you can now deploy your application like this:
 
     > appengine-deploy
+
+to start the development server:
+
+    > appengine-dev-server
+
+to redeploy development server continuously:
+
+    > ~ appengine-dev-server
 
 sample
 ======

--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,11 @@ description := "sbt plugin to deploy on appengine"
 
 licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-appengine/blob/master/LICENSE"))
 
-libraryDependencies <+= (sbtVersion) { sv =>
-  "com.github.siasia" %% "xsbt-web-plugin" % (sv + "-0.2.10")
-}
+libraryDependencies <++= (scalaVersion, sbtVersion) { (scalaV, sv) => Seq(
+  "com.github.siasia" %% "xsbt-web-plugin" % (sv + "-0.2.10"),
+  "cc.spray" % "sbt-revolver" % "0.6.0" extra("scalaVersion" -> scalaV, "sbtVersion" -> sv)
+    from "http://repo.spray.cc/cc/spray/sbt-revolver_2.9.1_0.11.2/0.6.0/sbt-revolver-0.6.0.jar"
+)}
 
 scalacOptions := Seq("-deprecation", "-unchecked")
 
@@ -32,6 +34,8 @@ publishArtifact in (Compile, packageDoc) := false
 publishArtifact in (Compile, packageSrc) := false
 
 resolvers += "Maven.org" at "http://repo1.maven.org/maven2"
+
+resolvers += "spray repo" at "http://repo.spray.cc"
 
 seq(lsSettings :_*)
 

--- a/src/sbt-test/sbt-appengine/helloxmpp/project/plugins.sbt
+++ b/src/sbt-test/sbt-appengine/helloxmpp/project/plugins.sbt
@@ -1,1 +1,3 @@
+resolvers += "spray repo" at "http://repo.spray.cc"
+
 addSbtPlugin("com.eed3si9n" % "sbt-appengine" % "0.3.2-SNAPSHOT")

--- a/src/sbt-test/sbt-appengine/simple/project/plugins.sbt
+++ b/src/sbt-test/sbt-appengine/simple/project/plugins.sbt
@@ -1,1 +1,3 @@
+resolvers += "spray repo" at "http://repo.spray.cc"
+
 addSbtPlugin("com.eed3si9n" % "sbt-appengine" % "0.3.2-SNAPSHOT")


### PR DESCRIPTION
Inspired by the discussion in #4, I've reimplemented appengine development server invocation that's closer to the original 0.7 sbt-appengine-plugin's feel by launching it in a forked vm. By tracking the process using sbt-revolver it's able to continuously redeploy out of the box. With some minor tweak it should be able to support JRebel as well.

I'm sending this as a pull request to get feedbacks.
