### PR TITLE
Fix backends support.

### DIFF
--- a/src/main/scala/AppenginePlugin.scala
+++ b/src/main/scala/AppenginePlugin.scala
@@ -81,7 +81,7 @@ object Plugin extends sbt.Plugin {
           sys.error("error executing appcfg: required parameter missing")
         }
         val x = depends.value
-        appcfgTaskCmd(gae.appcfgPath.value, opts, Seq("backends", gae.temporaryWarPath.value.getAbsolutePath) ++ args, streams.value)
+        appcfgTaskCmd(gae.appcfgPath.value, opts, Seq("backends", gae.temporaryWarPath.value.getAbsolutePath, action) ++ args, streams.value)
       }
     def appcfgTaskCmd(appcfgPath: sbt.File, args: Seq[String],
                               params: Seq[String], s: TaskStreams) = {


### PR DESCRIPTION
Hello,

I was using backends in 0.5.0 (with SBT 0.12) but when I tried switching to SBT 0.13 and sbt-appengine 0.6.0, appengine-deploy-backends started failing.

appcfgBackendTask was ignoring it's action parameter, causing
appcfg.sh to print usage information. Looks like the problem
was introduced in 50552f4954dfe69ba6365fdb3537efdd0efb1ba4.
