### PR TITLE
Fix version regexp for App Engine 1.9.10 or later

### DIFF
--- a/src/main/scala/AppenginePlugin.scala
+++ b/src/main/scala/AppenginePlugin.scala
@@ -105,7 +105,7 @@ object Plugin extends sbt.Plugin {
     }
 
     def buildSdkVersion(libUserPath: File): String = {
-      val pat = """appengine-api-1.0-sdk-(\d\.\d\.\d(?:\.\d)*)\.jar""".r
+      val pat = """appengine-api-1.0-sdk-(\d\.\d+\.\d+(?:\.\d+)*)\.jar""".r
       (libUserPath * "appengine-api-1.0-sdk-*.jar").get.toList match {
         case jar::_ => jar.name match {
           case pat(version) => version


### PR DESCRIPTION
This pull request fixes the invalid jar file error with App Engine 1.9.10 (reported as #31).
It assumes that the version format is `a.b.c` or `a.b.c.d`, b/c/d is a number of 1 or more digits.
