### PR TITLE
update dependency in test project

### DIFF
--- a/src/sbt-test/sbt-appengine/simple/build.sbt
+++ b/src/sbt-test/sbt-appengine/simple/build.sbt
@@ -2,10 +2,10 @@ import sbtappengine.Plugin.{AppengineKeys => gae}
 
 name := "sample"
 
-scalaVersion := "2.9.2"
+scalaVersion := "2.11.11"
 
 libraryDependencies ++= Seq(
-  "net.databinder" %% "unfiltered-filter" % "0.6.4",
+  "ws.unfiltered" %% "unfiltered-filter" % "0.9.1",
   "javax.servlet" % "servlet-api" % "2.5" % "provided",
   "org.mortbay.jetty" % "jetty" % "6.1.22" % "container"
 )

--- a/src/sbt-test/sbt-appengine/simple/src/main/scala/counter.scala
+++ b/src/sbt-test/sbt-appengine/simple/src/main/scala/counter.scala
@@ -3,7 +3,7 @@ package simple
 import javax.jdo.annotations._
 import javax.jdo._
 import com.google.appengine.api.datastore.Key
-import scala.annotation.target.field
+import scala.annotation.meta.field
 
 @PersistenceCapable
 case class Counter(

--- a/src/sbt-test/sbt-appengine/simple/src/main/scala/echofilter.scala
+++ b/src/sbt-test/sbt-appengine/simple/src/main/scala/echofilter.scala
@@ -1,15 +1,18 @@
 package simple
 
+import unfiltered.filter.Plan
 import unfiltered.request._
 import unfiltered.response._
 import unfiltered.request.{Path => UFPath}
 import com.google.appengine.api.datastore.{Key, KeyFactory}
 
-class EchoFilter extends unfiltered.filter.Planify ({
-  case GET(UFPath(Seg(what :: Nil)) & Params(params0)) =>
-    val key = KeyFactory.createKey(classOf[Counter].getSimpleName, what)
-    val counter = CounterAdapter.get(key) getOrElse new Counter(key, 0)
-    val inc = new Counter(key, counter.count + 1)
-    CounterAdapter.save(inc)
-    ResponseString(what + inc.count.toString + "!")
-})
+class EchoFilter extends Plan {
+  override val intent: Plan.Intent = {
+    case GET(UFPath(Seg(what :: Nil)) & Params(params0)) =>
+      val key = KeyFactory.createKey(classOf[Counter].getSimpleName, what)
+      val counter = CounterAdapter.get(key) getOrElse new Counter(key, 0)
+      val inc = new Counter(key, counter.count + 1)
+      CounterAdapter.save(inc)
+      ResponseString(what + inc.count.toString + "!")
+  }
+}


### PR DESCRIPTION
- use Scala 2.11
- use latest version unfiltered (0.9.1)
- s/scala.annotation.target.field/scala.annotation.meta.field https://github.com/scala/scala/commit/4e86106b5b0637aa88de2e3d5a8751d918e4c069
- use Plan instead of Planify (compile error)

```
sbt-appengine/src/sbt-test/sbt-appengine/simple/src/main/scala/echofilter.scala:8: Implementation restriction: <$anon: unfiltered.request.HttpRequest[javax.servlet.http.HttpServletRequest] => unfiltered.response.ResponseFunction[javax.servlet.http.HttpServletResponse]> requires premature access to class EchoFilter.
[error] class EchoFilter extends unfiltered.filter.Planify ({
[error]                                                     ^
[error] one error found
[error] (compile:compileIncremental) Compilation failed
```